### PR TITLE
Restore WS_CHILD window style for Embedded Windows

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1400,6 +1400,9 @@ namespace Avalonia.Win32
 
                 WindowStyles style = WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_OVERLAPPEDWINDOW | WindowStyles.WS_CLIPSIBLINGS;
 
+                if (this is EmbeddedWindowImpl)
+                    style |= WindowStyles.WS_CHILD;
+
                 if (IsWindowVisible(_hwnd))
                     style |= WindowStyles.WS_VISIBLE;
 


### PR DESCRIPTION
## What does the pull request do?
Restore WS_CHILD window style for embedded windows.

## What is the current behavior?
Embedded windows in hosted scenarios are not child windows causing all sorts of focus and other issues.

## What is the updated/expected behavior with this PR?
Embedded windows will have WS_CHILD style applied.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation


## Fixed issues
Fixes #16048